### PR TITLE
using account address in slots instead of pub keys

### DIFF
--- a/src/components/schedule/schedule-modal/index.tsx
+++ b/src/components/schedule/schedule-modal/index.tsx
@@ -179,7 +179,7 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
       onClose({
         id: meeting.id,
         created_at: new Date(meeting.created_at),
-        account_pub_key: currentAccount!.internal_pub_key,
+        account_address: currentAccount!.address,
         meeting_info_file_path: meeting.meeting_info_file_path,
         start: new Date(meeting.start),
         end: new Date(meeting.end),

--- a/src/types/Meeting.ts
+++ b/src/types/Meeting.ts
@@ -46,7 +46,7 @@ export interface TimeSlot {
 export interface DBSlot extends TimeSlot {
   id?: string
   created_at?: Date
-  account_pub_key: string
+  account_address: string
   meeting_info_file_path: string
 }
 

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -195,7 +195,7 @@ const updateAccountFromInvite = async (
     const { _, error } = await db.supabase
       .from('slots')
       .update({
-        account_pub_key: newIdentity.publicKey,
+        account_address: newIdentity.address,
         meeting_info_file_path: newEncryptedPath,
       })
       .match({ id: slot.id })
@@ -301,7 +301,7 @@ const getSlotsForAccount = async (
   const { data, error } = await db.supabase
     .from('slots')
     .select()
-    .eq('account_pub_key', account.internal_pub_key)
+    .eq('account_address', account.address)
     .or(
       `and(start.gte.${_start},end.lte.${_end}),and(start.lte.${_start},end.gte.${_end}),and(start.gt.${_start},end.lte.${_end}),and(start.gte.${_start},end.lt.${_end})`
     )
@@ -329,7 +329,7 @@ const getSlotsForDashboard = async (
   const { data, error } = await db.supabase
     .from('slots')
     .select()
-    .eq('account_pub_key', account.internal_pub_key)
+    .eq('account_address', account.address)
     .gte('end', _end)
     .range(offset, offset + limit)
     .order('start')
@@ -482,7 +482,7 @@ const saveMeeting = async (
         id: participant.slot_id,
         start: meeting.start,
         end: meeting.end,
-        account_pub_key: account.internal_pub_key,
+        account_address: account.address,
         meeting_info_file_path: path,
       }
 


### PR DESCRIPTION
**Description**
no need to use pub keys as joins between slots and accounts, we can use the wallet address itself

**Migrations**

1. We need to add a column `account_address` of type text to the `slots` table
2. execute script migration that is in this text
3. drop column `account_pub_key` from `slots` table after validation


**Script Migration**
`update slots set account_address = (select act.address from accounts act where act.internal_pub_key = account_pub_key)`
