### PR TITLE
notice time input bug fix

### DIFF
--- a/src/components/profile/MeetingTypesConfig.tsx
+++ b/src/components/profile/MeetingTypesConfig.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   Button,
   Checkbox,
-  Flex,
   Grid,
   GridItem,
   Heading,
@@ -257,7 +256,7 @@ const TypeConfig: React.FC<TypeConfigProps> = ({ goBack, account, typeId }) => {
         <Input
           width="140px"
           type="number"
-          value={minAdvanceTime.amount}
+          value={minAdvanceTime.amount.toString()}
           onChange={e => {
             setMinAdvanceTime({
               amount: Number(e.target.value),


### PR DESCRIPTION
With the value as a string, now when the user backspace, it turns to zero but as the user types again the leading zero is removed.