### PR TITLE
Solvers #244 and #287: set consent mode so we always get a refresh token

### DIFF
--- a/src/pages/api/secure/calendar_integrations/google/connect.ts
+++ b/src/pages/api/secure/calendar_integrations/google/connect.ts
@@ -31,6 +31,7 @@ export default async function handler(
 
     const authUrl = oAuth2Client.generateAuthUrl({
       access_type: 'offline',
+      prompt: 'consent',
       scope: scopes,
     })
 


### PR DESCRIPTION
Without consent mode we can have users not receiving the refresh token