### PR TITLE
fix scheduling a meeting with no display name

### DIFF
--- a/src/components/schedule/base-dialog.tsx
+++ b/src/components/schedule/base-dialog.tsx
@@ -292,7 +292,7 @@ export const BaseMeetingDialog: React.FC<BaseMeetingDialogProps> = ({
       (participants.length === 1 &&
         (participants[0]?.account_address?.toLowerCase() ===
           currentAccount!.address.toLowerCase() ||
-          participants[0]?.name === currentAccount!.preferences?.name))
+          participants[0]?.name === (currentAccount!.preferences?.name || '')))
     ) {
       toast({
         title: 'Missing participants',


### PR DESCRIPTION
If a non-domain name participant is added to a meeting, and the logged in user has not yet set a display name, it will be falsely deemed the logged in user is trying to add only themselves to the meeting.