### PR TITLE
disable cancel button when updating meeting and vice versa

### DIFF
--- a/src/components/schedule/base-dialog.tsx
+++ b/src/components/schedule/base-dialog.tsx
@@ -138,6 +138,7 @@ export const BaseMeetingDialog: React.FC<BaseMeetingDialogProps> = ({
   )
 
   const [isScheduling, setIsScheduling] = useState(false)
+  const [isCancelling, setIsCancelling] = useState(false)
   const [searchingTimes, setSearchingTimes] = useState(false)
   const [groupTimes, setGroupTimes] = useState<Interval[] | undefined>(
     undefined
@@ -709,6 +710,7 @@ export const BaseMeetingDialog: React.FC<BaseMeetingDialogProps> = ({
               onClick={cancelMeeting}
               variant="outline"
               mr={4}
+              disabled={isScheduling}
             >
               Cancel meeting
             </Button>
@@ -717,6 +719,7 @@ export const BaseMeetingDialog: React.FC<BaseMeetingDialogProps> = ({
             onClick={scheduleOrUpdate}
             colorScheme={'orange'}
             isLoading={isScheduling}
+            disabled={isCancelling}
           >
             {meeting?.id ? 'Update' : 'Schedule'}
           </Button>
@@ -727,6 +730,7 @@ export const BaseMeetingDialog: React.FC<BaseMeetingDialogProps> = ({
         onClose={onClose}
         decriptedMeeting={decryptedMeeting}
         currentAccount={currentAccount}
+        onCancelChange={setIsCancelling}
         afterCancel={removed =>
           onDialogClose(MeetingChangeType.DELETE, undefined, removed)
         }

--- a/src/components/schedule/cancel-dialog.tsx
+++ b/src/components/schedule/cancel-dialog.tsx
@@ -17,6 +17,7 @@ import { cancelMeeting } from '@/utils/calendar_manager'
 interface CancelMeetingDialogProps {
   decriptedMeeting?: MeetingDecrypted
   currentAccount?: Account | null
+  onCancelChange?: (isCancelling: boolean) => void
   afterCancel?: (slotsRemoved: string[]) => void
   isOpen: boolean
   onClose: () => void
@@ -25,12 +26,17 @@ interface CancelMeetingDialogProps {
 export const CancelMeetingDialog: React.FC<CancelMeetingDialogProps> = ({
   decriptedMeeting,
   currentAccount,
+  onCancelChange,
   afterCancel,
   isOpen,
   onClose,
 }) => {
   const cancelRef = React.useRef<HTMLButtonElement>(null)
-  const [cancelling, setCancelling] = useState(false)
+  const [cancelling, _setCancelling] = useState(false)
+  const setCancelling = (isCancelling: boolean) => {
+    onCancelChange && onCancelChange(isCancelling)
+    _setCancelling(isCancelling)
+  }
   const toast = useToast()
 
   return (


### PR DESCRIPTION
Decided it was better to have the `onCancelChange` callback in `CancelMeetingDialog` take the value of the updated state rather than relying on `afterCancel`, since that only gets called on a successful cancel