### PR TITLE
Fix Meeting Edit Dialog Timezone Conversion to Display Correct Local Time

### DIFF
--- a/src/pages/dashboard/schedule.tsx
+++ b/src/pages/dashboard/schedule.tsx
@@ -1,6 +1,6 @@
 import { Container, Flex, useDisclosure, useToast } from '@chakra-ui/react'
 import { addMinutes, differenceInMinutes } from 'date-fns'
-import { zonedTimeToUtc } from 'date-fns-tz'
+import { utcToZonedTime } from 'date-fns-tz'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import React, { useContext, useEffect, useState } from 'react'
@@ -864,8 +864,8 @@ const Schedule: NextPage<IInitialProps> = ({
       setGroupAvailability({
         no_group: allAddresses,
       })
-      const start = zonedTimeToUtc(meeting.start, timezone)
-      const end = zonedTimeToUtc(meeting.end, timezone)
+      const start = utcToZonedTime(meeting.start, timezone)
+      const end = utcToZonedTime(meeting.end, timezone)
       const diffInMinutes = differenceInMinutes(end, start)
       setParticipants(participants)
 


### PR DESCRIPTION
- Fix meeting edit dialog to correctly display scheduled time in the user's local timezone.