### PR TITLE
Show only last 5 commits in deployment summary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,8 +56,8 @@ jobs:
         echo "## 📋 What Changed in This Deployment:" >> $GITHUB_ENV
         echo "" >> $GITHUB_ENV
         
-        # Get last 10 commits with enhanced descriptions
-        git --no-pager log --pretty=format:"%s%n%b" -10 | while IFS= read -r commit; do
+        # Get last 5 commits with enhanced descriptions
+        git --no-pager log --pretty=format:"%s%n%b" -5 | while IFS= read -r commit; do
           # Convert technical terms to user-friendly language
           enhanced_commit=$(echo "$commit" | \
             sed -E 's/^fix(\([^)]+\))?:/🐛 **Bug Fix:** /i' | \


### PR DESCRIPTION
Updated the deploy workflow to include only the last 5 commits, instead of 10, in the deployment summary. This helps keep the deployment notes concise and focused.