### PR TITLE
fix: Hide add contact button in production environment

### DIFF
--- a/src/components/meeting/MeetingScheduledDialog.tsx
+++ b/src/components/meeting/MeetingScheduledDialog.tsx
@@ -34,6 +34,7 @@ import {
   setNotificationSubscriptions,
 } from '@/utils/api_helper'
 import { dateToHumanReadable } from '@/utils/calendar_manager'
+import { isProduction } from '@/utils/constants'
 import {
   CantInviteYourself,
   ContactAlreadyExists,
@@ -286,7 +287,7 @@ const MeetingScheduledDialog: React.FC<IProps> = ({
           </VStack>
         ) : !!currentAccount ? (
           <VStack gap={4}>
-            {!isContact ? (
+            {!isContact && !isProduction ? (
               <Button
                 colorScheme="primary"
                 width="100%"


### PR DESCRIPTION
Updated MeetingScheduledDialog to conditionally render the add contact button only in non-production environments. This prevents users from seeing the button in production if the contact does not exist.