### PR TITLE
feat: Add 'Description' label to meeting description in emails

### DIFF
--- a/src/emails/new_meeting/html.pug
+++ b/src/emails/new_meeting/html.pug
@@ -305,7 +305,8 @@ html(xmlns='http://www.w3.org/1999/xhtml', xmlns:o='urn:schemas-microsoft-com:of
                                                         if meeting.description
                                                             p(style='line-height: 1.5; font-family: inherit; word-break: break-word; font-size: 16px; mso-line-height-alt: 24px; margin-top: 16px;')
                                                                 span(class='description', style='font-size: 16px;')
-                                                                    != meeting.description
+                                                                    strong Description
+                                                                    | : !{meeting.description}
 
                                                         if changeUrl && cancelUrl
                                                             p(style='line-height: 1.5; font-family: inherit; word-break: break-word; font-size: 16px; mso-line-height-alt: 24px; margin-top: 16px;')

--- a/src/emails/new_meeting_scheduler/html.pug
+++ b/src/emails/new_meeting_scheduler/html.pug
@@ -305,7 +305,8 @@ html(xmlns='http://www.w3.org/1999/xhtml', xmlns:o='urn:schemas-microsoft-com:of
                                                         if meeting.description
                                                             p(style='line-height: 1.5; font-family: inherit; word-break: break-word; font-size: 16px; mso-line-height-alt: 24px; margin-top: 16px;')
                                                                 span(class='description', style='font-size: 16px;')
-                                                                    != meeting.description
+                                                                    strong Description
+                                                                    | : !{meeting.description}
 
                                                         if changeUrl && cancelUrl
                                                             p(style='line-height: 1.5; font-family: inherit; word-break: break-word; font-size: 16px; mso-line-height-alt: 24px; margin-top: 16px;')


### PR DESCRIPTION
Updated the new meeting and meeting scheduler email templates to prepend a 'Description:' label before the meeting description, improving clarity for recipients.