### PR TITLE
chore: Refactor meeting type calendar filtering logic

### DIFF
--- a/src/components/public-meeting/index.tsx
+++ b/src/components/public-meeting/index.tsx
@@ -61,7 +61,6 @@ import {
 import { saveMeetingsScheduled } from '@utils/storage'
 import { getAccountDisplayName } from '@utils/user_manager'
 import { addMinutes, addMonths, endOfMonth, startOfMonth } from 'date-fns'
-import { zonedTimeToUtc } from 'date-fns-tz'
 import { DateTime, Interval } from 'luxon'
 import { useRouter } from 'next/router'
 import React, { FC, useEffect, useMemo, useState } from 'react'
@@ -761,14 +760,7 @@ const PublicPage: FC<IProps> = props => {
       let busySlots: Interval[] = []
       try {
         busySlots = (
-          await getBusySlots(
-            currentAccount?.address,
-            startDate,
-            endDate,
-            undefined,
-            undefined,
-            selectedType?.id
-          )
+          await getBusySlots(currentAccount?.address, startDate, endDate)
         ).map(slot =>
           Interval.fromDateTimes(
             DateTime.fromJSDate(new Date(slot.start)),
@@ -820,14 +812,7 @@ const PublicPage: FC<IProps> = props => {
 
     try {
       busySlots = (
-        await getBusySlots(
-          props?.account?.address,
-          startDate,
-          endDate,
-          undefined,
-          undefined,
-          selectedType?.id
-        )
+        await getBusySlots(props?.account?.address, startDate, endDate)
       ).map(slot =>
         Interval.fromDateTimes(
           DateTime.fromJSDate(new Date(slot.start)),

--- a/src/pages/api/meetings/busy/[identifier].ts
+++ b/src/pages/api/meetings/busy/[identifier].ts
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/nextjs'
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import { AccountNotFoundError } from '@/utils/errors'
-import { extractQuery } from '@/utils/generic_utils'
 import { CalendarBackendHelper } from '@/utils/services/calendar.backend.helper'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -32,8 +31,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
           startDate,
           endDate,
           limit,
-          offset,
-          extractQuery<string>(req.query, 'meetingTypeId')
+          offset
         )
 
       return res.status(200).json(busySlots)

--- a/src/utils/api_helper.ts
+++ b/src/utils/api_helper.ts
@@ -519,17 +519,13 @@ export const getBusySlots = async (
   start?: Date,
   end?: Date,
   limit?: number,
-  offset?: number,
-  meetingTypeId?: string
+  offset?: number
 ): Promise<Interval[]> => {
-  let url = `/meetings/busy/${accountIdentifier}?limit=${
+  const url = `/meetings/busy/${accountIdentifier}?limit=${
     limit || undefined
   }&offset=${offset || 0}&start=${start?.getTime() || undefined}&end=${
     end?.getTime() || undefined
   }`
-  if (meetingTypeId) {
-    url += `&meetingTypeId=${meetingTypeId}`
-  }
   const response = await queryClient.fetchQuery(
     QueryKeys.busySlots({
       id: accountIdentifier?.toLowerCase(),

--- a/src/utils/services/calendar.backend.helper.ts
+++ b/src/utils/services/calendar.backend.helper.ts
@@ -24,8 +24,7 @@ export const CalendarBackendHelper = {
     startDate: Date,
     endDate: Date,
     limit?: number,
-    offset?: number,
-    meetingTypeId?: string
+    offset?: number
   ): Promise<TimeSlot[]> => {
     const busySlots: TimeSlot[] = []
 
@@ -49,17 +48,9 @@ export const CalendarBackendHelper = {
     }
 
     const getIntegratedCalendarEvents = async () => {
-      let calendars = await getConnectedCalendars(account_address, {
+      const calendars = await getConnectedCalendars(account_address, {
         activeOnly: true,
       })
-      if (meetingTypeId) {
-        const meetingType = await getMeetingTypeFromDB(meetingTypeId)
-        if (meetingType.calendars) {
-          calendars = calendars.filter(calendar =>
-            meetingType.calendars?.some(c => c.id === calendar.id)
-          )
-        }
-      }
       await Promise.all(
         calendars.map(async calendar => {
           const integration = getConnectedCalendarIntegration(


### PR DESCRIPTION
Moved calendar filtering by meeting type from busy slot retrieval to event sync operations. Simplified busy slot API and related helper functions by removing meetingTypeId parameter, ensuring calendar filtering is only applied during event creation, update, and deletion. Improves separation of concerns and reduces unnecessary complexity in busy slot queries.