### PR TITLE
Rename PollStatus CANCELLED to CLOSED

### DIFF
--- a/src/components/quickpoll/PastPolls.tsx
+++ b/src/components/quickpoll/PastPolls.tsx
@@ -36,7 +36,7 @@ const PastPolls = ({ searchQuery = '' }: PastPollsProps) => {
         (currentPage - 1) * QUICKPOLL_DEFAULT_LIMIT,
         debouncedSearchQuery,
         PollStatus.COMPLETED,
-        PollStatus.CANCELLED,
+        PollStatus.CLOSED,
         PollStatus.EXPIRED
       ),
     onError: (err: unknown) => {

--- a/src/components/quickpoll/PollCard.tsx
+++ b/src/components/quickpoll/PollCard.tsx
@@ -76,7 +76,7 @@ const PollCard = ({
 
   const isPastPoll =
     poll.status === PollStatus.COMPLETED ||
-    poll.status === PollStatus.CANCELLED ||
+    poll.status === PollStatus.CLOSED ||
     poll.status === PollStatus.EXPIRED ||
     pollIsExpired
 
@@ -145,7 +145,7 @@ const PollCard = ({
     switch (status) {
       case PollStatus.ONGOING:
         return { bg: 'green.100', color: 'green.700' }
-      case PollStatus.CANCELLED:
+      case PollStatus.CLOSED:
         return { bg: 'red.100', color: 'red.400' }
       case PollStatus.COMPLETED:
         return { bg: 'blue.100', color: 'blue.700' }

--- a/src/providers/MetricStateProvider.tsx
+++ b/src/providers/MetricStateProvider.tsx
@@ -71,7 +71,7 @@ const MetricStateProvider: React.FC<{
           QUICKPOLL_DEFAULT_OFFSET,
           searchQuery || '',
           PollStatus.COMPLETED,
-          PollStatus.CANCELLED,
+          PollStatus.CLOSED,
           PollStatus.EXPIRED
         ),
       ])

--- a/src/types/QuickPoll.ts
+++ b/src/types/QuickPoll.ts
@@ -9,9 +9,8 @@ import { CalendarSyncInfo } from './CalendarConnections'
 export enum PollStatus {
   ONGOING = 'ongoing',
   COMPLETED = 'completed',
-  CANCELLED = 'cancelled',
-  EXPIRED = 'expired',
   CLOSED = 'closed',
+  EXPIRED = 'expired',
 }
 
 export enum PollVisibility {


### PR DESCRIPTION
Change enum value and update all usages across API, database, and UI components to use CLOSED instead of CANCELLED