### PR TITLE
feat: Add private links announcement modal

### DIFF
--- a/src/components/privacy/PrivacyPolicyModal.tsx
+++ b/src/components/privacy/PrivacyPolicyModal.tsx
@@ -43,9 +43,13 @@ const isEmailRequiredError = (e: unknown): boolean => {
 
 export interface PrivacyPolicyModalProps {
   isOpen: boolean
+  onAccepted?: () => void
 }
 
-const PrivacyPolicyModal = ({ isOpen }: PrivacyPolicyModalProps) => {
+const PrivacyPolicyModal = ({
+  isOpen,
+  onAccepted,
+}: PrivacyPolicyModalProps) => {
   const { showSuccessToast } = useToastHelpers()
   const { currentAccount, updateUser } = useContext(AccountContext)
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -129,6 +133,7 @@ const PrivacyPolicyModal = ({ isOpen }: PrivacyPolicyModalProps) => {
         QueryKeys.account(currentAccount?.address?.toLowerCase())
       )
       await updateUser()
+      if (onAccepted) onAccepted()
     },
     onError: (e: unknown) => {
       if (isEmailRequiredError(e)) {

--- a/src/components/privacy/PrivateLinksAnnouncementModal.tsx
+++ b/src/components/privacy/PrivateLinksAnnouncementModal.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import {
+  Box,
+  Button,
+  Checkbox,
+  Flex,
+  Image,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalOverlay,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { FiArrowRight } from 'react-icons/fi'
+
+import { getGoogleMeetAuthUrl } from '@/utils/api_helper'
+import { useToastHelpers } from '@/utils/toasts'
+
+export interface PrivateLinksAnnouncementModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export const PrivateLinksAnnouncementModal = ({
+  isOpen,
+  onClose,
+}: PrivateLinksAnnouncementModalProps) => {
+  const router = useRouter()
+  const { showErrorToast } = useToastHelpers()
+  const [connectGoogle, setConnectGoogle] = useState(false)
+  const [isConnecting, setIsConnecting] = useState(false)
+
+  const handleContinue = async () => {
+    if (!connectGoogle) {
+      onClose()
+      return
+    }
+
+    setIsConnecting(true)
+    try {
+      const state = Buffer.from(
+        JSON.stringify({
+          redirectTo: router.asPath,
+          origin: 'announcement',
+        })
+      ).toString('base64')
+
+      const { url } = await getGoogleMeetAuthUrl(state)
+      window.open(url, '_self')
+      onClose()
+    } catch {
+      setIsConnecting(false)
+      showErrorToast(
+        'Connection failed',
+        'Could not connect to Google Meet. Please try again.'
+      )
+    }
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      isCentered
+      size="xl"
+      closeOnOverlayClick={false}
+      closeOnEsc={false}
+    >
+      <ModalOverlay bg="blackAlpha.700" backdropFilter="blur(10px)" />
+      <ModalContent
+        bg="bg-surface"
+        borderRadius={{ base: 0, md: '12px' }}
+        border="1px solid"
+        borderColor="border-wallet-subtle"
+        p={0}
+        overflow="hidden"
+        maxW="592px"
+        width={{ base: '100%', md: '592px' }}
+        boxShadow="none"
+        shadow="none"
+      >
+        <ModalBody p={0}>
+          <Box p={{ base: 6, md: 8 }}>
+            <Text color="text-primary" fontWeight="bold" fontSize="2xl" mb={2}>
+              Introducing Private Meeting links for Meet & Zoom
+            </Text>
+
+            <Text color="text-secondary" fontSize="sm" mb={6}>
+              March 2025
+            </Text>
+
+            <VStack align="start" spacing={4} mb={8}>
+              <Text color="text-primary" fontWeight="bold" fontSize="lg">
+                Your meeting links are now private
+              </Text>
+              <Text color="text-primary" fontSize="md">
+                Until now, every link Meetwith generated was public — anyone
+                with it could walk straight in. That changes today.
+              </Text>
+              <Text color="text-primary" fontSize="md">
+                Connect your Google Meet or Zoom account and every meeting you
+                book through Meetwith automatically gets a private link. Invited
+                guests join directly. Anyone else lands in a waiting room until
+                you let them in.
+              </Text>
+              <Text color="text-primary" fontSize="md" fontWeight="medium">
+                Connect your accounts below to activate it.
+              </Text>
+            </VStack>
+
+            <Box
+              borderTop="1px solid"
+              borderColor="border-wallet-subtle"
+              pt={6}
+            >
+              <VStack align="stretch" spacing={4}>
+                <Flex align="center" gap={4}>
+                  <Checkbox
+                    colorScheme="primary"
+                    isChecked={connectGoogle}
+                    onChange={e => setConnectGoogle(e.target.checked)}
+                    size="lg"
+                  />
+                  <Flex align="center" gap={3}>
+                    <Image
+                      src="/assets/connected-accounts/google-meet.png"
+                      w="24px"
+                      h="24px"
+                      alt="Google Meet"
+                    />
+                    <Text color="text-primary" fontSize="md">
+                      Connect your Google Meet Account here
+                    </Text>
+                  </Flex>
+                </Flex>
+
+                {/* Zoom OAuth not yet implemented — hidden until user OAuth flow is built */}
+                <Flex align="center" gap={4} display="none">
+                  <Checkbox colorScheme="primary" size="lg" isDisabled />
+                  <Flex align="center" gap={3}>
+                    <Image
+                      src="/assets/connected-accounts/zoom.png"
+                      w="24px"
+                      h="24px"
+                      alt="Zoom"
+                    />
+                    <Text color="text-primary" fontSize="md">
+                      Connect your Zoom Account here
+                    </Text>
+                  </Flex>
+                </Flex>
+              </VStack>
+            </Box>
+          </Box>
+
+          <Box
+            bg="bg-surface-secondary"
+            p={{ base: 4, md: 6 }}
+            borderTop="1px solid"
+            borderColor="border-wallet-subtle"
+            display="flex"
+            justifyContent="flex-end"
+          >
+            <Button
+              bg="primary.400"
+              color="white"
+              _hover={{ bg: 'primary.500' }}
+              transition="background 0.2s ease"
+              borderRadius="8px"
+              fontSize="16px"
+              px={6}
+              py={3}
+              rightIcon={<FiArrowRight />}
+              onClick={handleContinue}
+              isLoading={isConnecting}
+              loadingText="Connecting"
+              width={{ base: '100%', md: 'auto' }}
+            >
+              Continue
+            </Button>
+          </Box>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/components/profile/DashboardContent.tsx
+++ b/src/components/profile/DashboardContent.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, HStack } from '@chakra-ui/react'
 import dynamic from 'next/dynamic'
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import { useLocalStorage } from 'usehooks-ts'
 import type { PrivacyPolicyModalProps } from '@/components/privacy/PrivacyPolicyModal'
 import NotFound from '@/pages/404'
@@ -17,6 +17,14 @@ import Contact from './Contact'
 
 const PrivacyPolicyModal = dynamic<PrivacyPolicyModalProps>(
   () => import('@/components/privacy/PrivacyPolicyModal'),
+  { ssr: false }
+)
+
+const PrivateLinksAnnouncementModal = dynamic(
+  () =>
+    import('@/components/privacy/PrivateLinksAnnouncementModal').then(
+      mod => mod.PrivateLinksAnnouncementModal
+    ),
   { ssr: false }
 )
 
@@ -84,9 +92,27 @@ const DashboardContent: React.FC<{
 
   const showPrivacyModal = currentAccount?.preferences?.terms_accepted === null
 
+  const [showAnnouncement, setShowAnnouncement] = useState(true)
+
+  const handleCloseAnnouncement = () => {
+    setShowAnnouncement(false)
+  }
+
+  const handlePrivacyPolicyAccepted = () => {
+    setShowAnnouncement(true)
+  }
+
   return currentAccount ? (
     <MetricStateProvider currentAccount={currentAccount}>
-      {showPrivacyModal && <PrivacyPolicyModal isOpen />}
+      {showPrivacyModal && (
+        <PrivacyPolicyModal isOpen onAccepted={handlePrivacyPolicyAccepted} />
+      )}
+      {showAnnouncement && !showPrivacyModal && (
+        <PrivateLinksAnnouncementModal
+          isOpen={showAnnouncement}
+          onClose={handleCloseAnnouncement}
+        />
+      )}
       <HStack
         alignItems="start"
         width="100%"


### PR DESCRIPTION
Triggers automatically after the privacy policy is accepted. Adds support for Google Meet OAuth connection directly from the modal, using state parameters to redirect users back to their current page. The Zoom option is temporarily hidden until a user OAuth flow is built.