### PR TITLE
refactor: improve calendar integration and state management in QuickPoll

### DIFF
--- a/src/components/quickpoll/PublicPollScheduleView.tsx
+++ b/src/components/quickpoll/PublicPollScheduleView.tsx
@@ -131,6 +131,7 @@ function PublicPollScheduleViewInner({
   const hasAppliedCalendarPreviewRef = useRef(false)
   const dismissedPendingCalendarRef = useRef(false)
   const selectedSlotsRef = useRef(selectedSlots)
+  const loadSlotsRef = useRef(loadSlots)
   const [showMethodModal, setShowMethodModal] = useState(false)
   const [showConnectCalendarModal, setShowConnectCalendarModal] =
     useState(false)
@@ -144,6 +145,10 @@ function PublicPollScheduleViewInner({
   useEffect(() => {
     selectedSlotsRef.current = selectedSlots
   }, [selectedSlots])
+
+  useEffect(() => {
+    loadSlotsRef.current = loadSlots
+  }, [loadSlots])
 
   useEffect(() => {
     if (router.query.calendarPending !== '1') return
@@ -234,6 +239,7 @@ function PublicPollScheduleViewInner({
   useEffect(() => {
     if (!isEditing) return
     if (dismissedPendingCalendarRef.current) return
+    if (hasAppliedCalendarPreviewRef.current) return
 
     let cancelled = false
     const run = async () => {
@@ -265,7 +271,7 @@ function PublicPollScheduleViewInner({
             start: s.start,
           }))
         }
-        loadSlots(selected)
+        loadSlotsRef.current(selected)
         setCalendarPreviewActive(true)
         hasAppliedCalendarPreviewRef.current = true
       } catch {}
@@ -279,7 +285,6 @@ function PublicPollScheduleViewInner({
     duration,
     endDate,
     isEditing,
-    loadSlots,
     pollEnd,
     pollStart,
     startDate,

--- a/src/pages/api/quickpoll/calendar/google/callback.ts
+++ b/src/pages/api/quickpoll/calendar/google/callback.ts
@@ -132,7 +132,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           provider: TimeSlotSource.GOOGLE,
           email: userInfoRes.data.email!,
           payload: key as Record<string, unknown>,
-          calendars,
         }
         await req.session.save()
         const sep = redirectTo.includes('?') ? '&' : '?'

--- a/src/pages/api/quickpoll/calendar/office365/callback.ts
+++ b/src/pages/api/quickpoll/calendar/office365/callback.ts
@@ -152,7 +152,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         provider: TimeSlotSource.OFFICE,
         email: String(userData.mail || userData.userPrincipalName || ''),
         payload: tokenData as Record<string, unknown>,
-        calendars,
       }
       await req.session.save()
       const sep = redirectTo.includes('?') ? '&' : '?'

--- a/src/pages/api/quickpoll/create.ts
+++ b/src/pages/api/quickpoll/create.ts
@@ -16,6 +16,7 @@ import {
   QuickPollCreationError,
   QuickPollValidationError,
 } from '@/utils/errors'
+import { CalendarBackendHelper } from '@/utils/services/calendar.backend.helper'
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -96,12 +97,16 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       )
       if (schedulerId) {
         try {
+          const calendars =
+            await CalendarBackendHelper.getCalendarsForPendingQuickPollCalendar(
+              pending
+            )
           await saveQuickPollCalendar(
             schedulerId,
             pending.email,
             pending.provider,
             pending.payload,
-            pending.calendars
+            calendars
           )
         } catch (calendarError) {
           Sentry.captureException(calendarError)

--- a/src/types/QuickPoll.ts
+++ b/src/types/QuickPoll.ts
@@ -103,7 +103,6 @@ export interface QuickPollPendingCalendar {
   provider: string
   email: string
   payload: Record<string, unknown>
-  calendars: CalendarSyncInfo[]
 }
 
 export interface QuickPollPendingCalendarPreviewResponse {

--- a/src/utils/services/calendar.backend.helper.ts
+++ b/src/utils/services/calendar.backend.helper.ts
@@ -247,8 +247,9 @@ export const CalendarBackendHelper = {
     )
 
     try {
+      const calendars = await integration.refreshConnection()
       const calendarIds =
-        pending.calendars
+        calendars
           ?.filter((c: CalendarSyncInfo) => c.enabled)
           .map((c: CalendarSyncInfo) => c.calendarId) || []
       const externalSlots = await integration.getAvailability(
@@ -262,6 +263,25 @@ export const CalendarBackendHelper = {
         source: pending.provider as TimeSlotSource,
         start: new Date(it.start),
       }))
+    } catch (e: unknown) {
+      Sentry.captureException(e)
+      return []
+    }
+  },
+
+  getCalendarsForPendingQuickPollCalendar: async (
+    pending: QuickPollPendingCalendar
+  ): Promise<CalendarSyncInfo[]> => {
+    const integration = getConnectedCalendarIntegration(
+      '',
+      pending.email,
+      pending.provider as TimeSlotSource,
+      pending.payload
+    )
+
+    try {
+      const calendars = await integration.refreshConnection()
+      return calendars || []
     } catch (e: unknown) {
       Sentry.captureException(e)
       return []


### PR DESCRIPTION
- Introduced CalendarBackendHelper to fetch calendars for pending quick polls, enhancing calendar integration.
- Updated PublicPollScheduleView to utilize a ref for loadSlots, improving state management during slot loading.
- Removed unnecessary calendars property from QuickPollPendingCalendar interface to streamline data handling.
- Adjusted Google and Office365 callback handlers to eliminate redundant calendar data, ensuring cleaner session management.